### PR TITLE
🔧 Fix kotlinx-datetime version and prevent compat versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,10 @@
       excludePackageNames: [
         'org.jetbrains.kotlinx{/,}**',
       ],
+    },
+    {
+      matchPackageNames: ['org.jetbrains.kotlinx:kotlinx-datetime'],
+      allowedVersions: '!/.*-.*-compat$/',
     }
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
     },
     {
       matchPackageNames: ['org.jetbrains.kotlinx:kotlinx-datetime'],
-      allowedVersions: '!/.*-.*-compat$/',
+      allowedVersions: '!/compat/',
     }
   ],
 }

--- a/build-src/libs.versions.toml
+++ b/build-src/libs.versions.toml
@@ -37,7 +37,7 @@ exposed = "0.61.0"
 # dev dep
 # multiplatform
 dev-serializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
-dev-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat"
+dev-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.7.1"
 dev-kotlinLogging = "io.github.oshai:kotlin-logging:7.0.7"
 dev-coroutinesBom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2"
 dev-koinBom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }


### PR DESCRIPTION
## Summary
- Fixed kotlinx-datetime version from 0.7.0-0.6.x-compat to 0.7.0
- Added Renovate configuration to prevent future updates to compatibility versions

## Background
Renovate incorrectly updated kotlinx-datetime to the compatibility version `0.7.0-0.6.x-compat` instead of the actual release version `0.7.0`. The compatibility version is meant for migration purposes, not for production use.

## Changes
- Updated `kotlinx-datetime` dependency from `0.7.0-0.6.x-compat` to `0.7.0` in build-src/libs.versions.toml
- Added Renovate package rule to block versions ending with `-compat` for kotlinx-datetime

## Test plan
- [x] Verify the project builds successfully with kotlinx-datetime 0.7.0
- [ ] Confirm Renovate will no longer suggest compatibility versions

🤖 Generated with [Claude Code](https://claude.ai/code)