### PR TITLE
feat: redesign MainNavState to support username in Favourite section

### DIFF
--- a/conduit-frontend/frontend-compose-ui/src/androidMain/kotlin/mikufan/cx/conduit/frontend/ui/screen/main/MainNavPage.preview.kt
+++ b/conduit-frontend/frontend-compose-ui/src/androidMain/kotlin/mikufan/cx/conduit/frontend/ui/screen/main/MainNavPage.preview.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.flow
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavComponent
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavComponentChild
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavIntent
-import mikufan.cx.conduit.frontend.logic.component.main.MainNavMode
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavState
 import mikufan.cx.conduit.frontend.logic.component.main.feed.ArticlesListComponent
 import mikufan.cx.conduit.frontend.logic.component.main.feed.ArticlesListDetailNavComponent
@@ -70,7 +69,7 @@ fun MainPagePreview() {
         )
       )
       override val state: StateFlow<MainNavState> =
-        MutableStateFlow(MainNavState(MainNavMode.NOT_LOGGED_IN, 0))
+        MutableStateFlow(MainNavState.notLoggedIn())
 
       override fun send(intent: MainNavIntent) = Unit
     }
@@ -94,7 +93,7 @@ fun MainPagePreviewForLoginUser() {
         )
       )
       override val state: StateFlow<MainNavState> =
-        MutableStateFlow(MainNavState(MainNavMode.LOGGED_IN, 0))
+        MutableStateFlow(MainNavState.loggedIn("testuser"))
 
       override fun send(intent: MainNavIntent) = Unit
     }

--- a/conduit-frontend/frontend-compose-ui/src/commonMain/kotlin/mikufan/cx/conduit/frontend/ui/screen/main/MainNavPage.kt
+++ b/conduit-frontend/frontend-compose-ui/src/commonMain/kotlin/mikufan/cx/conduit/frontend/ui/screen/main/MainNavPage.kt
@@ -22,7 +22,6 @@ import mikufan.cx.conduit.frontend.logic.component.main.MainNavComponent
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavComponentChild
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavIntent
 import mikufan.cx.conduit.frontend.logic.component.main.MainNavMenuItem
-import mikufan.cx.conduit.frontend.logic.component.main.MainNavMode
 import mikufan.cx.conduit.frontend.ui.screen.main.auth.AuthPage
 import mikufan.cx.conduit.frontend.ui.screen.main.feed.ArticlesListDetailPanel
 import mikufan.cx.conduit.frontend.ui.screen.main.me.MeNavPage
@@ -35,10 +34,10 @@ fun MainNavPage(component: MainNavComponent, modifier: Modifier = Modifier) {
   val stack by component.childStack.subscribeAsState()
 
   val selectedIndex by remember { derivedStateOf { mainNavState.pageIndex } }
-  val mainStateMode by remember { derivedStateOf { mainNavState.mode } }
+  val menuItems = remember { derivedStateOf { mainNavState.menuItems } }
 
-  val manuItems = remember(mainStateMode) { // not using derivedStateOf because it updates whenever mainStateMode changes
-    navigationItems(mainStateMode, component::send)
+  val manuItems = remember(menuItems.value) { // not using derivedStateOf because it updates whenever menuItems changes
+    navigationItems(menuItems.value, component::send)
   }
 
   NavigationSuiteScaffold(
@@ -70,10 +69,10 @@ fun MainNavPage(component: MainNavComponent, modifier: Modifier = Modifier) {
 
 
 private fun navigationItems(
-  mainStateMode: MainNavMode,
+  menuItems: List<MainNavMenuItem>,
   onSend: (MainNavIntent) -> Unit,
 ): List<NavigationItem> {
-  return mainStateMode.menuItems.withIndex().map { (index, value) ->
+  return menuItems.withIndex().map { (index, value) ->
     mapMenuItemEnum2NavItem(value, index, onSend)
   }
 }
@@ -92,7 +91,7 @@ private fun mapMenuItemEnum2NavItem(
 ): NavigationItem {
   val icon = when (value) {
     MainNavMenuItem.Feed -> Icons.Filled.Home
-    MainNavMenuItem.Favourite -> Icons.Filled.Favorite
+    is MainNavMenuItem.Favourite -> Icons.Filled.Favorite
     MainNavMenuItem.Me -> Icons.Filled.Person
     MainNavMenuItem.SignInUp -> Icons.Filled.Person
   }

--- a/conduit-frontend/frontend-compose-ui/src/commonMain/kotlin/mikufan/cx/conduit/frontend/ui/screen/main/MainNavPage.kt
+++ b/conduit-frontend/frontend-compose-ui/src/commonMain/kotlin/mikufan/cx/conduit/frontend/ui/screen/main/MainNavPage.kt
@@ -36,13 +36,13 @@ fun MainNavPage(component: MainNavComponent, modifier: Modifier = Modifier) {
   val selectedIndex by remember { derivedStateOf { mainNavState.pageIndex } }
   val menuItems = remember { derivedStateOf { mainNavState.menuItems } }
 
-  val manuItems = remember(menuItems.value) { // not using derivedStateOf because it updates whenever menuItems changes
+  val navItems = remember(menuItems.value) { // not using derivedStateOf because it updates whenever menuItems changes
     navigationItems(menuItems.value, component::send)
   }
 
   NavigationSuiteScaffold(
     navigationSuiteItems = {
-      manuItems.forEach { item ->
+      navItems.forEach { item ->
         item(
           icon = { Icon(item.icon, contentDescription = item.label) },
           label = { Text(item.label) },

--- a/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.component.kt
+++ b/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.component.kt
@@ -86,9 +86,8 @@ class DefaultMainNavComponent(
     Config.MainFeed -> MainNavComponentChild.MainFeed(
       articleListDetailComponentFactory.create(componentContext)
     )
-    Config.Favourite -> {
-      // TODO: need to depend on the user config properly
-      val searchFilter = ArticlesSearchFilter(favoritedByUsername = "CXwudi")
+    is Config.Favourite -> {
+      val searchFilter = ArticlesSearchFilter(favoritedByUsername = config.username)
       MainNavComponentChild.Favourite(
         articleListDetailComponentFactory.create(componentContext, searchFilter)
       )
@@ -103,7 +102,7 @@ class DefaultMainNavComponent(
 
   private fun enumToConfig(enum: MainNavMenuItem): Config = when (enum) {
     MainNavMenuItem.Feed -> Config.MainFeed
-    MainNavMenuItem.Favourite -> Config.Favourite
+    is MainNavMenuItem.Favourite -> Config.Favourite(enum.username)
     MainNavMenuItem.Me -> Config.Me
     MainNavMenuItem.SignInUp -> Config.SignInUp
   }
@@ -115,7 +114,7 @@ class DefaultMainNavComponent(
     data object MainFeed : Config
 
     @Serializable
-    data object Favourite : Config
+    data class Favourite(val username: String) : Config
 
     @Serializable
     data object Me : Config

--- a/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.model.kt
+++ b/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.model.kt
@@ -10,8 +10,7 @@ data class MainNavState private constructor(
   val currentMenuItem: MainNavMenuItem
     get() = menuItems[pageIndex]
 
-  fun indexOfMenuItem(menuItem: MainNavMenuItem): Int? = 
-    menuItems.withIndex().firstOrNull { it.value == menuItem }?.index
+  fun indexOfMenuItem(menuItem: MainNavMenuItem): Int? = menuItems.indexOf(menuItem).takeIf { it != -1 }
 
   val isLoggedIn: Boolean
     get() = menuItems.any { it is MainNavMenuItem.Favourite }
@@ -26,6 +25,7 @@ data class MainNavState private constructor(
     }
 
     fun loggedIn(username: String, pageIndex: Int = 0): MainNavState {
+      require(username.isNotBlank()) { "Username cannot be blank" }
       val menuItems = listOf(
         MainNavMenuItem.Feed,
         MainNavMenuItem.Favourite(username),

--- a/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.model.kt
+++ b/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.model.kt
@@ -1,55 +1,67 @@
 package mikufan.cx.conduit.frontend.logic.component.main
 
-data class MainNavState(
-  val mode: MainNavMode,
+data class MainNavState private constructor(
+  val menuItems: List<MainNavMenuItem>,
   /**
    * This index is used for navigation bar to indicate which page is selected
    */
   val pageIndex: Int,
 ) {
   val currentMenuItem: MainNavMenuItem
-    get() = mode.menuItems[pageIndex]
+    get() = menuItems[pageIndex]
 
+  fun indexOfMenuItem(menuItem: MainNavMenuItem): Int? = 
+    menuItems.withIndex().firstOrNull { it.value == menuItem }?.index
 
-  fun indexOfMenuItem(menuItem: MainNavMenuItem): Int? = mode.indexMap[menuItem]
+  val isLoggedIn: Boolean
+    get() = menuItems.any { it is MainNavMenuItem.Favourite }
+
+  companion object {
+    fun notLoggedIn(pageIndex: Int = 0): MainNavState {
+      val menuItems = listOf(
+        MainNavMenuItem.Feed,
+        MainNavMenuItem.SignInUp
+      )
+      return MainNavState(menuItems, pageIndex.coerceIn(0, menuItems.size - 1))
+    }
+
+    fun loggedIn(username: String, pageIndex: Int = 0): MainNavState {
+      val menuItems = listOf(
+        MainNavMenuItem.Feed,
+        MainNavMenuItem.Favourite(username),
+        MainNavMenuItem.Me
+      )
+      return MainNavState(menuItems, pageIndex.coerceIn(0, menuItems.size - 1))
+    }
+  }
 }
 
-/**
- * This class can probably be inlined,
- * but it is better to keep it as it serves as an indicator telling if the user is logged in
- */
-enum class MainNavMode(
-  val menuItems: List<MainNavMenuItem>,
-) {
-  NOT_LOGGED_IN(
-    listOf(
-      MainNavMenuItem.Feed,
-      MainNavMenuItem.SignInUp
-    )
-  ),
-  LOGGED_IN(
-    listOf(
-      MainNavMenuItem.Feed,
-      MainNavMenuItem.Favourite,
-      MainNavMenuItem.Me
-    )
-  );
-  internal val indexMap: Map<MainNavMenuItem, Int> = menuItems.withIndex().associate { it.value to it.index }
-}
-
-enum class MainNavMenuItem(
-  val menuName: String,
-) {
-  Feed("Feeds"),
-  Favourite("Favourites"),
-  Me("Me"),
-  SignInUp("Sign in/up"),
+sealed interface MainNavMenuItem {
+  val menuName: String
+  
+  data object Feed : MainNavMenuItem {
+    override val menuName: String = "Feeds"
+  }
+  
+  data class Favourite(
+    val username: String
+  ) : MainNavMenuItem {
+    override val menuName: String = "Favourites"
+  }
+  
+  data object Me : MainNavMenuItem {
+    override val menuName: String = "Me"
+  }
+  
+  data object SignInUp : MainNavMenuItem {
+    override val menuName: String = "Sign in/up"
+  }
 }
 
 /**
  * Intents for navigation in the main page
  */
 sealed interface MainNavIntent {
-  data class ModeSwitching(val targetMode: MainNavMode): MainNavIntent
+  data class StateSwitching(val targetState: MainNavState): MainNavIntent
   data class MenuItemSwitching(val targetMenuItem: MainNavMenuItem): MainNavIntent
 }

--- a/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.store.kt
+++ b/conduit-frontend/frontend-decompose-logic/src/commonMain/kotlin/mikufan/cx/conduit/frontend/logic/component/main/MainNav.store.kt
@@ -39,7 +39,7 @@ class MainNavStoreFactory(
         val newMenuItem = intent.targetMenuItem
         val currentState = state()
         val newIdx: Int = requireNotNull(currentState.indexOfMenuItem(newMenuItem)) {
-          "$newMenuItem not found in $currentState, this should not happen"
+          "MenuItem $newMenuItem not found in state with items: ${currentState.menuItems}. Current pageIndex: ${currentState.pageIndex}"
         }
         if (currentState.pageIndex != newIdx) {
           log.info { "Switching to page at index $newIdx" }


### PR DESCRIPTION
Fixes #55

This PR redesigns the MainNavState model to properly support passing username to the Favourite section instead of using hardcoded values.

## Changes
- Convert MainNavMenuItem from enum to sealed interface with username parameter
- Make MainNavState constructor private with factory methods (notLoggedIn, loggedIn)
- Update store to pass username from UserConfigState.OnLogin to Favourite menu item
- Remove hardcoded "CXwudi" username, now uses actual username from user config
- Update UI components to work with new sealed interface structure
- Update preview components to use new factory methods

## Benefits
- Type safety: Username only available where needed
- Controlled creation: Private constructor prevents invalid state
- Architecture improvement: Clear separation between logged in/out states
- Username propagation: Username flows from user config to components
- Maintainability: Factory methods ensure consistent state creation

Generated with [Claude Code](https://claude.ai/code)